### PR TITLE
Add 'vendor' to excludes. 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -64,4 +64,4 @@ kramdown:
     coderay_css: class
 
 include: [".htaccess"]
-exclude: ["lib", "config.rb", "Capfile", "config", "log", "Rakefile", "Rakefile.rb", "tmp", "less", "so-simple-theme.sublime-project", "so-simple-theme.sublime-workspace"]
+exclude: ["lib", "config.rb", "Capfile", "config", "log", "Rakefile", "Rakefile.rb", "tmp", "less", "so-simple-theme.sublime-project", "so-simple-theme.sublime-workspace", "vendor"]


### PR DESCRIPTION
If bundler installs gems into `vendor`, jekyll barfs on `jekyll serve`, because it tries to build out pages for its tests.
