### PR TITLE
Added stackexchange icon to footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ owner:
   twitter:        
   facebook:       
   github:         
+  stackexchange:  
   linkedin:       
   instagram:      
   flickr:         

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,8 +2,9 @@
 <div class="social-icons">
 	{% if site.owner.twitter %}<a href="http://twitter.com/{{ site.owner.twitter }}" title="{{ site.owner.name}} on Twitter" target="_blank"><i class="icon-twitter icon-2x"></i></a>{% endif %}
 	{% if site.owner.facebook %}<a href="http://facebook.com/{{ site.owner.facebook }}" title="{{ site.owner.name}} on Facebook" target="_blank"><i class="icon-facebook icon-2x"></i></a>{% endif %}
-	{% if site.owner.google_plus %}<a href="{{ site.owner.google_plus }}" target="{{ site.owner.name}} on Google+" target="_blank"><i class="icon-google-plus icon-2x"></i></a>{% endif %}
+	{% if site.owner.google_plus %}<a href="{{ site.owner.google_plus }}" title="{{ site.owner.name}} on Google+" target="_blank"><i class="icon-google-plus icon-2x"></i></a>{% endif %}
 	{% if site.owner.linkedin %}<a href="http://linkedin.com/in/{{ site.owner.linkedin }}" title="{{ site.owner.name}} on LinkedIn" target="_blank"><i class="icon-linkedin icon-2x"></i></a>{% endif %}
+	{% if site.owner.stackexchange %}<a href="{{ site.owner.stackexchange }}" title="{{ site.owner.name}} on StackExchange" target="_blank"><i class="icon-stackexchange icon-2x"></i></a>{% endif %}
 	{% if site.owner.instagram %}<a href="http://instagram.com/{{ site.owner.instagram }}" title="{{ site.owner.name}} on Instagram" target="_blank"><i class="icon-instagram icon-2x"></i></a>{% endif %}
 	{% if site.owner.flickr %}<a href="http://www.flickr.com/photos/{{ site.owner.flickr }}" title="{{ site.owner.name}} on Flickr" target="_blank"><i class="icon-flickr icon-2x"></i></a>{% endif %}
 	{% if site.owner.github %}<a href="http://github.com/{{ site.owner.github }}" title="{{ site.owner.name}} on Github" target="_blank"><i class="icon-github icon-2x"></i></a>{% endif %}


### PR DESCRIPTION
The Font Awesome already includes the icon for stackexchange. So it just needed updating `footer.html` and adding a line in `_config.yml`. In config file one should pass a url not the id. That is because a link to the profile on stackexchange.com might not be desirable. Some people are only active in one of the sites in SE network (e.g. stackoverflow.com) so it can be up to user to choose which profile should be linked.
You can see how it looks like in my [under-construction page](http://tuix.github.io/).

Also minor fix in google+ link in `footer.html`: no title/2 targets.
