### PR TITLE
Change the @alt-font from volkhorn to volkhov

### DIFF
--- a/assets/less/variables.less
+++ b/assets/less/variables.less
@@ -5,7 +5,7 @@
 @heading-font: @base-font;
 @caption-font: @base-font;
 @code-font: 'source-code-pro', monospace;
-@alt-font: 'volkorn', serif;
+@alt-font: 'volkhov', serif;
 
 @doc-font-size: 16;
 @doc-line-height: 24;


### PR DESCRIPTION
In _head.html we're loading volkhov.js from edgefonts, but in
variables.less it was referencing volkorn. I don't see volkorn
loaded anywhere, so I'm assuming it's a typo.
