### PR TITLE
Bugfix .author-photo vs .author-photo width

### DIFF
--- a/assets/less/page.less
+++ b/assets/less/page.less
@@ -257,7 +257,7 @@ span + .entry-title {
 	a { color: @text-color; }
 	@media @large {
 		float: left;
-		width: 140px;
+		width: 150px;
 		margin: 0 40px 40px 0;
 		padding: 0;
 	}


### PR DESCRIPTION
The author-photo is 150px, but the entry-meta div only 140px. This squeezes the author photo by 10px and makes it look strange.
