### PR TITLE
Add unique disqus_identifier

### DIFF
--- a/_includes/disqus_comments.html
+++ b/_includes/disqus_comments.html
@@ -2,6 +2,10 @@
     /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
     var disqus_shortname = '{{ site.disqus_shortname }}'; // required: replace example with your forum shortname
 
+    {% if page.uuid %}
+      var disqus_identifier = '{{ page.uuid }}';
+    {% endif %}
+
     /* * * DON'T EDIT BELOW THIS LINE * * */
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;


### PR DESCRIPTION
Use an optional `uuid` YAML variable to uniquely identify a page for Disqus. This helps match comments with a post in the event of changing page URL, domain, etc. See http://help.disqus.com/customer/portal/articles/472098-javascript-configuration-variables#disqus_identifier