### PR TITLE
Display the default image in case the avatar not available

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,10 +25,18 @@
       </header>
       <footer class="entry-meta">
         {% if page.author.name %}
+        {% if page.author.avatar %}
         <img src="{{ site.url }}/images/{{ page.author.avatar }}" alt="{{ page.author.name }} photo" class="author-photo">
+        {% else %}
+        <img src="{{ site.url }}/images/bio-photo-alt.jpg" alt="{{ page.author.name }} photo" class="author-photo">
+        {% endif %}
         <span class="author vcard">By <span class="fn">{{ page.author.name }}</span></span>
         {% else %}
+        {% if site.owner.avatar %}
         <img src="{{ site.url }}/images/{{ site.owner.avatar }}" alt="{{ site.owner.name }} photo" class="author-photo">
+        {% else %}
+        <img src="{{ site.url }}/images/bio-photo-alt.jpg" alt="{{ site.owner.name }} photo" class="author-photo">
+        {% endif %}
         <span class="author vcard">By <span class="fn"><a href="{{ site.url }}/about/" title="About {{ site.owner.name }}">{{ site.owner.name }}</a></span></span>
         {% endif %}
         <span class="entry-date date published"><time datetime="{{ page.date | date_to_xmlschema }}"><i class="icon-calendar-empty"></i> {{ page.date | date: "%B %d, %Y" }}</time></span>


### PR DESCRIPTION
**Note** that whenever content is written by another author, the existence of an avatar for that author is questionable, so adding another if-else block ensures that instead of the alt, the default image is shown

Thus, whenever the site owner or the new author, do not provide an "avatar", then instead of the alt text (which does not look good in the circular shape) the default image is shown.

Before:

![before](http://snag.gy/QOKsz.jpg)

After:

![after](http://snag.gy/Bm3n8.jpg)

As is obvious from the above two images, without the author avatar, the site loses its consistency.
