### PR TITLE
Change Twitter share to use tags instead of categories as hashtags.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -47,7 +47,7 @@
         <span class="social-share-facebook">
             <a href="https://www.facebook.com/sharer/sharer.php?u={{ site.url }}{{ page.url }}" title="Share on Facebook" itemprop="Facebook"><i class="icon-facebook-sign"></i> Like</a></span>
         <span class="social-share-twitter">
-            <a href="https://twitter.com/intent/tweet?hashtags={{ page.categories | join: ',' }}&text={{ page.title | escape | replace:' ','%20' }}&url={{ site.url }}{{ page.url }}&via={{site.owner.twitter}}" title="Share on Twitter" itemprop="Twitter"><i class="icon-twitter-sign"></i> Tweet</a></span>
+            <a href="https://twitter.com/intent/tweet?hashtags={{ page.tags | join: ',' | remove: ' ' }}&text={{ page.title | escape | replace:' ','%20' }}&url={{ site.url }}{{ page.url }}&via={{site.owner.twitter}}" title="Share on Twitter" itemprop="Twitter"><i class="icon-twitter-sign"></i> Tweet</a></span>
         <span class="social-share-googleplus">
             <a href="https://plus.google.com/share?url={{ site.url }}{{ page.url }}" title="Share on Google Plus" itemprop="GooglePlus"><i class="icon-google-plus-sign"></i> +1</a></span>
             <!-- /.social-share -->{% endif %}


### PR DESCRIPTION
The way so-simple is set up, categories are more of a hierarchy for organizing posts in "virtual" folders, whereas tags seem more relevant to the content of the article.

Changes the twitter link to use tags instead of categories when creating the hashtags in the link.
Also removes spaces in tags with multiple words.

For example:

| post tags | twitter hashtags |
| --- | --- |
| [open source] | #opensource |
| [java] | #java |
| [open source, java] | #opensource #java |
