### PR TITLE
fix(nav): clicking anywhere when the nav menu is hidden no longer opens it

### DIFF
--- a/assets/js/_main.js
+++ b/assets/js/_main.js
@@ -16,7 +16,9 @@ var navigation = responsiveNav("#site-nav", { // Selector: The ID of the wrapper
 
 $('html').click(function() {
   //Hide the menus if visible
-  navigation.toggle();
+  if ($(navigation.wrapper).hasClass('opened')) {
+  	navigation.toggle();
+  }
 });
 
 $('#site-nav').click(function(event){


### PR DESCRIPTION
It seems that on small viewports, clicking anywhere is opening the navigation menu. This should fix that.

`.wrapper` does not seem to be a documented property of https://github.com/viljamis/responsive-nav.js, but it felt less wrong than other options.

I also briefly tried to upgrade to a newer version, since they have a public `.close()` method now, but it seemed it wouldn't be trivial.
