### PR TITLE
Adding class for centering in markdown

### DIFF
--- a/_sass/_site.scss
+++ b/_sass/_site.scss
@@ -263,6 +263,9 @@ pre {
 .no-scroll {
 	overflow: hidden;
 }
+.center{
+	text-align: center;
+}
 
 
 // Global Transition


### PR DESCRIPTION
With this you can easily center text by use of markdown's _IALs_ (Block Inline Attribute Lists).

**Example:**
{:.center}
Your text

**Will result in:**
`<p class="center">Your text</p>`

So CSS will "text-align:center".
