### PR TITLE
Support option if author.name is not set then don't display avatar and "By <name>" line

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -29,7 +29,7 @@
         {% endif %}
         {% if author.avatar contains 'http' %}
           <img src="{{ author.avatar }}" class="bio-photo" alt="{{ author.name }} bio photo"></a>
-        {% else %}
+        {% elsif author.avatar and author.avatar != blank %}
           <img src="{{ site.url }}/images/{{ author.avatar }}" class="bio-photo" alt="{{ author.name }} bio photo"></a>
         {% endif %}
         <span class="author vcard">By <span class="fn">{{ author.name }}</span></span>


### PR DESCRIPTION
I added a small change to check if the author.name is set. If not then the avatar pic and "By <name> lines are not displayed. This gives a simple way to hide the avatar and "By <name>" line. I basically did this as on my blog I am the only one posting I find it a bit unnecessary to include the author info in each post.

Hope you find this useful.
