### PR TITLE
added 'autofocus' to search page

### DIFF
--- a/search/index.md
+++ b/search/index.md
@@ -13,7 +13,7 @@ sitemap: false
 <!-- Search form -->
 <form method="get" action="{{ site.url }}/search/" data-search-form class="simple-search">
   <label for="q">Search {{ site.title }} for:</label>
-  <input type="search" name="q" id="q" placeholder="What are you looking for?" data-search-input id="goog-wm-qt" />
+  <input type="search" name="q" id="q" placeholder="What are you looking for?" data-search-input id="goog-wm-qt" autofocus />
   <input type="submit" value="Search" id="goog-wm-sb" />
 </form>
 


### PR DESCRIPTION
Added 'autofocus' attribute to automatically select the search input form upon page load (eliminates the need to 'click' in the input field before typing the search term).