### PR TITLE
Replace pygments by highlighter due to deprecation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,7 @@ links:
 # http://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 timezone:    America/New_York
 future:      true
-pygments:    true
+highlighter: pygments # Values supported rouge, pygments or null
 markdown:    kramdown
 
 # https://github.com/mojombo/jekyll/wiki/Permalinks


### PR DESCRIPTION
When jekyll serve is started, the following warning message is displayed : 

````
Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.
````

So I propose to change the default _config.yaml file to use highlighter