### PR TITLE
Hide author image when no author avatar is set

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -29,7 +29,7 @@
         {% endif %}
         {% if author.avatar contains 'http' %}
           <img src="{{ author.avatar }}" class="bio-photo" alt="{{ author.name }} bio photo"></a>
-        {% else %}
+        {% elsif author.avatar %}
           <img src="{{ site.url }}/images/{{ author.avatar }}" class="bio-photo" alt="{{ author.name }} bio photo"></a>
         {% endif %}
         <span class="author vcard">By <span class="fn">{{ author.name }}</span></span>


### PR DESCRIPTION
Currently if the author of a post has no avatar set you get a empty image container, this fix omits the author avatar when it is not set.