### PR TITLE
Add Cookie consent

### DIFF
--- a/_includes/cookieconsent.html
+++ b/_includes/cookieconsent.html
@@ -1,0 +1,7 @@
+<!-- Begin Cookie Consent plugin by Silktide - http://silktide.com/cookieconsent -->
+<script type="text/javascript">
+    window.cookieconsent_options = {"message":"This website uses cookies to ensure you get the best experience on our website. By using it you agree to our use of cookies.","dismiss":"Got it!","learnMore":"More info","link":"{{ site.url }}/privacy","theme":"dark-bottom"};
+</script>
+
+<script type="text/javascript" src="//s3.amazonaws.com/cc.silktide.com/cookieconsent.latest.min.js"></script>
+<!-- End Cookie Consent plugin -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -55,3 +55,6 @@
 <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ site.url }}/images/apple-touch-icon-114x114-precomposed.png">
 <!-- 144x144 (precomposed) for iPad 3rd and 4th generation -->
 <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.url }}/images/apple-touch-icon-144x144-precomposed.png">
+
+<!-- Cookie consent -->
+{% include cookieconsent.html %}

--- a/privacy/index.md
+++ b/privacy/index.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Privacy
+excerpt: "Privacy policy this website uses"
+---
+
+We use Google technologies to improve our content and keep it free.<br>
+Your web browser automatically sends certain information to Google. This includes, for example, the web address of the page that you're visiting and your IP address.<br>
+This website and the Google technologies we use may also set cookies on your browser, or read cookies that are already there.
+
+#####How we use the information sent by your browser:
+
+* Make ads more effective
+* Get Google Analytics to understand how visitors engage with our site
+* Meet our legal duties
+* Improve our products
+
+For more information check [Google Privacy & Terms](https://www.google.com/policies/privacy/partners/)


### PR DESCRIPTION
In this pull request I added a pretty basic Cookie consent module in response to "regulatory requirements issued by the European data protection authorities".

For more information I'll leave this link here http://cookiechoices.org/

I used the Cookie Consent by Silktide, which uses an ‘implied opt in’ method, the same approach that Google, Twitter and more have taken towards compliance: the website continues to use cookies but inform the user that by using the website he automatically agrees to the use of cookies.

It can be personalized more but for people like me that are not expert in web development it can be useful. A live version of this approach can be found on my blog http://desno365.net/
