### PR TITLE
Implement Medium-style read times

### DIFF
--- a/_includes/read-time.html
+++ b/_includes/read-time.html
@@ -1,0 +1,11 @@
+<span class="read-time" title="Estimated read time">
+  {% assign words = content | number_of_words %}
+  <i class="fa fa-bookmark">
+  {% if words < 360 %}
+    < 1 min read
+  {% else %}
+    {{ words | divided_by:180 }} min read
+  {% endif %}
+  </i>
+</span>
+<!-- /.read-time -->

--- a/_includes/read-time.html
+++ b/_includes/read-time.html
@@ -1,11 +1,10 @@
 <span class="read-time" title="Estimated read time">
   {% assign words = content | number_of_words %}
-  <i class="fa fa-bookmark">
+  <i class="fa fa-bookmark"></i>
   {% if words < 360 %}
     < 1 min read
   {% else %}
     {{ words | divided_by:180 }} min read
   {% endif %}
-  </i>
 </span>
 <!-- /.read-time -->

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -38,6 +38,7 @@
         <span class="entry-date date published"><time datetime="{{ page.date | date_to_xmlschema }}"><i class="fa fa-calendar-o"></i> {{ page.date | date: "%B %d, %Y" }}</time></span>
         {% if page.modified %}<span class="entry-date date modified"><time datetime="{{ page.modified }}"><i class="fa fa-pencil"></i> {{ page.modified | date: "%B %d, %Y" }}</time></span>{% endif %}
         {% if (site.owner.disqus-shortname and page.comments) or site.comments %}<span class="entry-comments"><i class="fa fa-comment-o"></i> <a href="#disqus_thread">Comment</a></span>{% endif %}
+        {% if page.readtime %}{% include read-time.html %}{% endif %}
         {% if page.share %}{% include social-share.html %}{% endif %}
         {% if page.ads == true %}{% include ad-sidebar.html %}<!-- /.google-ads -->{% endif %}
       </footer>


### PR DESCRIPTION
This is an enhancement, or a feature suggestion.

Similar to posts on Medium, there's a read time on each article, allowing users to gauge how long it takes to finish the article. Medium's read time is based on roughly 275 WPM, with time included for images, as shown [here](https://medium.com/the-story/read-time-and-you-bc2048ab620c). 

My implementation for this is only for 180 WPM, without accounting for images. If this is something you might like I can definitely work on it and add a more sophisticated counter for images!

As of now it's implemented in posts, and can be turned on using `readtime : true` on a per-post setting.

I'll be using this in my blog at [leewc.com](https://leewc.com), so I thought I'd work on it here for a Pull request if you're interested. Many thanks for the awesome theme! 

There's also the `fa bookmark-o` styled icon if you prefer. I tried both and it seems the filled one looks better, but I don't particularly have an eye for design :P 
