### PR TITLE
removed pro tip on applying for twitter cards

### DIFF
--- a/theme-setup/index.md
+++ b/theme-setup/index.md
@@ -318,8 +318,6 @@ Here's an example of a tweet with Twitter Cards enabled.
 
 ![Twitter Card summary large image screenshot]({{ site.url }}/images/twitter-card-summary-large-image.jpg)
 
-**Pro-Tip**: You need to [apply for Twitter Cards](https://dev.twitter.com/docs/cards) before they will begin showing up when links to your site are shared.
-{:.notice}
 
 ---
 


### PR DESCRIPTION
apparently this is no longer requried

documentation https://dev.twitter.com/cards/getting-started does not say anything about applying for this, and some googling indicates this may no longer be required