### PR TITLE
Updates Mathjax CDN

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -39,7 +39,7 @@
 
 {% if site.mathjax == true %}
 <!-- MathJax -->
-<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
 
 <!-- Icons -->


### PR DESCRIPTION
According to documentations and warning in the ```cosnole.log``` Mathjax CDN is changing. 

For more information see here:
https://www.mathjax.org/cdn-shutting-down/