### PR TITLE
Update Open Graph include to support og:image tag

### DIFF
--- a/_includes/open-graph.html
+++ b/_includes/open-graph.html
@@ -17,3 +17,8 @@
 {% if page.excerpt %}<meta property="og:description" content="{{ page.excerpt | strip_html }}">{% endif %}
 <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.url }}">
 <meta property="og:site_name" content="{{ site.title }}">
+{% if page.image.feature %}
+<meta property="og:image" content="{{ site.url }}/images/{{ page.image.feature }}">
+{% else %}
+<meta property="og:image" content="{% if page.image.thumb %}{{ site.url }}/images/{{ page.image.thumb }}{% else %}{{ site.url }}/images/{{ site.logo }}{% endif %}">
+{% endif %}


### PR DESCRIPTION
## Problem

FaceBook's Sharing Debugger currently issues a warning about a missing `og:image` tag.

For example: https://developers.facebook.com/tools/debug/sharing/?q=https%3A%2F%2Fmmistakes.github.io%2Fso-simple-theme%2F

## Solution

This commit contains additional template logic for outputting the missing tag.

## Notes

The changes borrow conditional logic from the Twitter Cards block to determine which image URL to output.