### PR TITLE
Change tag sort to be case insensitive

### DIFF
--- a/tags/index.md
+++ b/tags/index.md
@@ -6,7 +6,7 @@ search_omit: true
 ---
 
 {% capture site_tags %}{% for tag in site.tags %}{{ tag | first }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
-{% assign tags_list = site_tags | split:',' | sort %}
+{% assign tags_list = site_tags | split:',' | sort_natural %}
 
 <ul class="tag-box inline">
   {% for item in (0..site.tags.size) %}{% unless forloop.last %}


### PR DESCRIPTION
Change liquid sort from `sort` to `sort_natural `.

Past: Dog, apple, carrot, purple
Now: apple, carrot, Dog, purple