### PR TITLE
Sort collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,9 @@ This layout displays all documents grouped by a specific collection. It accommod
 ```yaml
 collection: # collection name
 entries_layout: # list (default), grid
+show_excerpts: # true (default), false
+sort_by: # date (default) title
+sort_order: # forward (default), reverse
 ```
 
 To create a page showing all documents in the `recipes` collection you'd create `recipes.md` in the root of your project and add this front matter:
@@ -648,7 +651,7 @@ permalink: /recipes/
 collection: recipes
 ```
 
-By default, documents are shown in a list view. To change to a grid view add `entries_layout: grid` to the page's front matter.
+By default, documents are shown in a list view. To change to a grid view add `entries_layout: grid` to the page's front matter. If you want to sort the collection by title add `sort_by: title`. If you want reverse sorting, add `sort_order: reverse`. If you are simply looking for list that shows recipe titles (no excerpts), add `show_excerpts: false`.
 
 ### `layout: category`
 

--- a/_config.yml
+++ b/_config.yml
@@ -53,7 +53,7 @@ feed:
 # Search
 search_full_content: false # can have performance implications for large sites
 
-# Taxonomoy pages
+# Taxonomy pages
 # category_archive_path: "/categories/#"
 # tag_archive_path: "/tags/#"
 

--- a/_includes/documents-collection.html
+++ b/_includes/documents-collection.html
@@ -1,3 +1,19 @@
-{%- for entry in site[include.collection] -%}
+{% assign entries = site[include.collection] %}
+
+{% if include.sort_by == 'title' %}
+  {% if include.sort_order == 'reverse' %}
+    {% assign entries = entries | sort: 'title' | reverse %}
+  {% else %}
+    {% assign entries = entries | sort: 'title' %}
+  {% endif %}
+{% elsif include.sort_by == 'date' %}
+  {% if include.sort_order == 'reverse' %}
+    {% assign entries = entries | sort: 'date' | reverse %}
+  {% else %}
+    {% assign entries = entries | sort: 'date' %}
+  {% endif %}
+{% endif %}
+
+{%- for entry in entries -%}
   {% include entry.html %}
 {%- endfor -%}

--- a/_layouts/collection.html
+++ b/_layouts/collection.html
@@ -5,5 +5,5 @@ layout: page
 {{ content }}
 
 <div class="entries-{{ page.entries_layout | default: 'list' }}">
-  {% include documents-collection.html collection=page.collection %}
+  {% include documents-collection.html collection=page.collection sort_by=page.sort_by sort_order=page.sort_order %}
 </div>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -56,7 +56,7 @@ paginate_path: /page:num/
 # Search
 search_full_content: false
 
-# Taxonomoy pages
+# Taxonomy pages
 category_archive_path: "/categories/#"
 tag_archive_path: "/tags/#"
 

--- a/example/_config.yml
+++ b/example/_config.yml
@@ -50,7 +50,7 @@ paginate_path: /page:num/
 # Search
 search_full_content: false
 
-# Taxonomoy pages
+# Taxonomy pages
 category_archive_path: "/categories/#"
 tag_archive_path: "/tags/#"
 


### PR DESCRIPTION
Added support for collection sorting. Updated README.md and fixed a typo in the _config.yml files.

The options `sort_by` and `sort_order` can be added in the front matter. Accepted values for The `sort_by`
option are the 'title' and 'date', and for the `sort_order` option is the 'reverse' (anything else will provide a forward ordering).

Example reverse sorting of recipes based on title:

---
title: Recipes
layout: collection
permalink: /recipes/
collection: recipes
show_excerpts: false
sort_by: title
sort_order: reverse
entries_layout: list
---