### PR TITLE
Disable atom feed footer_link by default.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -97,7 +97,7 @@ author:
       icon:
 
 # Footer Links
-footer_links:
-  - title: Feed
-    url: atom.xml
-    icon: fas fa-rss-square
+#footer_links:
+#  - title: Feed
+#    url: atom.xml
+#    icon: fas fa-rss-square


### PR DESCRIPTION
I want to remove the RSS feed, but since it is defined in the _config.yml of the theme this was not possible.