### PR TITLE
Keep search form from resetting when "enter" is hit

### DIFF
--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -4,7 +4,7 @@ layout: page
 
 {{ content }}
 
-<form>
+<form onsubmit="return false;">
   <input type="input" id="search" class="search-input" placeholder="{{ site.data.text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" autofocus>
 </form>
 


### PR DESCRIPTION
Users complain that they automatically hit enter when finished typing, and that resets the form.  This should fix that (checked in Safari, Chrome, FF, *not* IE yet)