### PR TITLE
Fix excerpts that run together because of implied spaces

### DIFF
--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -4,7 +4,7 @@ layout: page
 
 {{ content }}
 
-<form>
+<form onsubmit="return false;">
   <input type="input" id="search" class="search-input" placeholder="{{ site.data.text[site.locale].search_placeholder_text | default: 'Enter your search term...' }}" autofocus>
 </form>
 


### PR DESCRIPTION
When excerpts contain html that has implied whitespace (like a `<h2>` header followed by a `<p>`, but with no spaces in the text), add some whitespace *before* stripping the html, so that we see "Header paragraph" instead of "Headerparagraph" in the excerpt.