### PR TITLE
Added support for optional `target` attribute in footer_links

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,11 +814,12 @@ The footer links and copyright text can both be customized.
 
 Footer links are set in `_config.yml` under the `footer_links` key.
 
-| Name    | Description                                                                                                      |
-| ------- | ---------------------------------------------------------------------------------------------------------------- |
-| `title` | Describes the link. Not visible, used for accessibility purposes.                                                |
-| `url`   | URL the link points to.                                                                                          |
-| `icon`  | Corresponds with a [Font Awesome 5 icon](https://fontawesome.com/icons?d=gallery) e.g., `fab fa-twitter-square`. |
+| Name     | Description                                                                                                                                                                                  |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`  | Describes the link. Not visible, used for accessibility purposes.                                                                                                                            |
+| `url`    | URL the link points to.                                                                                                                                                                      |
+| `icon`   | Corresponds with a [Font Awesome 5 icon](https://fontawesome.com/icons?d=gallery) e.g., `fab fa-twitter-square`.                                                                             |
+| `target` | (Optional key) Sets the HTML [target](https://www.w3schools.com/tags/att_a_target.asp) attribute. Useful if the user wants the url to open in a new tab e.g. with the `_blank` target value. |
 
 **Examples:**
 
@@ -833,6 +834,7 @@ footer_links:
   - title: Feed
     url: atom.xml
     icon: fas fa-rss-square
+    target: _blank
 ```
 
 **Note:** To disable footer links completely use `footer_links: false`.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,7 +9,7 @@
         {%- else -%}
           {%- assign url = footer_link.url | relative_url -%}
         {%- endif -%}
-        <a class="social-icon" href="{{ url }}"><i class="{{ footer_link.icon | default: 'fas fa-link' }} fa-2x" title="{{ footer_link.title }}"></i></a>
+        <a class="social-icon" href="{{ url }}" {% if footer_link.target %}target="{{footer_link.target}}"{% endif %}><i class="{{ footer_link.icon | default: 'fas fa-link' }} fa-2x" title="{{ footer_link.title }}"></i></a>
       {%- endfor -%}
     </div>
   {%- endif -%}


### PR DESCRIPTION
by using the `target` key in the `_config.yaml`.
Updated the documentation to reflect this new feature.