### PR TITLE
Do not show footer in entry.html if not needed.

### DIFF
--- a/_includes/entry.html
+++ b/_includes/entry.html
@@ -32,8 +32,10 @@
       {% endif %}
     </div>
   {% endunless %}
-  <footer class="entry-meta">
-    {% if site.read_time %}{% include read-time.html %}{% endif %}
-    {% if entry.date %}{% include entry-date.html %}{% endif %}
-  </footer>
+  {% if site.read_time or entry.date and page.layout != 'collection' %}
+    <footer class="entry-meta">
+      {% if site.read_time %}{% include read-time.html %}{% endif %}
+      {% if entry.date %}{% include entry-date.html %}{% endif %}
+    </footer>
+  {% endif %}
 </article>


### PR DESCRIPTION
If there is no `site.read_time` or `entry.date` set, do not show an empty
footer as this only adds some whitespace. In a collection without
excerpts the whitespace between headers is already quite a lot due to
the article tag, so at least, do not add additional unnecessary
whitespace.

Note that the `entry.date` is not printed in a collection anyways (look at the `entry-date.html`), that why the `entry.date and page.layout != 'collection'` part of the code in the if statement.