### PR TITLE
Center hero image for large displays

### DIFF
--- a/_sass/so-simple/_page.scss
+++ b/_sass/so-simple/_page.scss
@@ -32,6 +32,10 @@
   @include breakpoint($large) {
     margin-top: (-2 * $site-logo-height) / 2;
   }
+  
+  img {
+    width: 100%;
+  }
 }
 
 .page-image-caption {

--- a/_sass/so-simple/_page.scss
+++ b/_sass/so-simple/_page.scss
@@ -20,6 +20,7 @@
 
 .page-image {
   position: relative;
+  text-align: center;
   margin-top: (-1 * $site-logo-height) / 2;
   margin-bottom: 2em;
   z-index: 1;


### PR DESCRIPTION
Just a quick change to center the hero image on large displays. Thanks for your work on this theme!

---
BEFORE
![markup__image_alignment___so_simple](https://user-images.githubusercontent.com/3844315/39597212-e0b65a0e-4ed1-11e8-93e8-8d9377e7b367.png)

---
AFTER
![markup__image_alignment___so_simple-2](https://user-images.githubusercontent.com/3844315/39597217-e1ffea38-4ed1-11e8-995d-0580a8c4621c.png)
