### PR TITLE
Clarified where to customize scss variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,7 +1041,7 @@ To override the default [Sass](http://sass-lang.com/guide) (located in theme's
 **Note:** To customize the actual Sass partials bundled
 in the gem, you will need to copy the complete contents of the `_sass` directory to `<your_project>`. Due to the way Jekyll currently imports these files it's all or nothing. Overriding a single Sass partial (or two) won't work like `_includes` and `_layouts`.
 
-To make basic tweaks to theme's style, Sass variables can be overridden by adding to `<your_project>/assets/stylesheets/main.scss`. For instance, to change the accent color used throughout the theme add the following after all `@import` lines:
+To make basic tweaks to theme's style, Sass variables can be overridden by adding to `<your_project>/assets/stylesheets/main.scss`. For instance, to change the accent color used throughout the theme add the following before all `@import` lines:
 
 ```scss
 $accent-color: tomato;


### PR DESCRIPTION
The documentation stated that lines to change variable names should be added to main.scss after @import statements. I tried this and it did not work for me. 

I then added these lines after the import statements and the customization works perfectly. 

According to [this post](https://stackoverflow.com/questions/17089717/how-to-overwrite-scss-variables-when-compiling-to-css) default variables (such as $accent-color) can be overwritten ahead of time. But changing the value of a variable after it has been used will not have any effect on the earlier parts of the CSS where the variable was used. 

Therefore, it seems like variables have to be overwritten after the import statements, and there is no way to overwrite variables that were not declared with !default.