### PR TITLE
allow to disable thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,7 @@ This layout displays all documents grouped by a specific collection. It accommod
 collection: # collection name
 entries_layout: # list (default), grid
 show_excerpts: # true (default), false
+show_thumbnails: # true (default), false
 sort_by: # date (default) title
 sort_order: # forward (default), reverse
 ```

--- a/_includes/entry.html
+++ b/_includes/entry.html
@@ -13,14 +13,16 @@
         <a href="{{ entry.url | relative_url }}" rel="bookmark">{{ title }}</a>
       {% endif %}
     </h3>
-    {% if entry.image.thumbnail %}
-      {% assign entry_image = entry.image.thumbnail %}
-      {% unless entry_image contains '://' %}
-        {% assign entry_image = entry_image | relative_url %}
-      {% endunless %}
-      {% assign entry_image = entry_image | escape %}
-      <img class="entry-image u-photo" src="{{ entry_image }}" alt="">
-    {% endif %}
+    {% unless page.show_thumbnails == false %}
+      {% if entry.image.thumbnail %}
+        {% assign entry_image = entry.image.thumbnail %}
+        {% unless entry_image contains '://' %}
+          {% assign entry_image = entry_image | relative_url %}
+        {% endunless %}
+        {% assign entry_image = entry_image | escape %}
+        <img class="entry-image u-photo" src="{{ entry_image }}" alt="">
+      {% endif %}
+    {% endunless %}
   </header>
   {% unless page.show_excerpts == false %}
     <div class="entry-excerpt p-summary">


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

using `show_thumbnail: false` in the configuration, one is able to disable the appearance of a thumbnail per post.
