### PR TITLE
allow for more control over when dates are shown on collection pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,6 +654,7 @@ This layout displays all documents grouped by a specific collection. It accommod
 ```yaml
 collection: # collection name
 entries_layout: # list (default), grid
+show_dates: # true (default for all other layouts)), false (default for 'collection' only)
 show_excerpts: # true (default), false
 sort_by: # date (default) title
 sort_order: # forward (default), reverse

--- a/_includes/entry-date.html
+++ b/_includes/entry-date.html
@@ -1,6 +1,4 @@
-{%- unless page.layout == 'collection' -%}
-  <time class="entry-date dt-published" datetime="{{ entry.date | date_to_xmlschema }}">
-    {%- assign date_format = site.date_format | default: "%B %-d, %Y" -%}
-    {{ entry.date | date: date_format }}
-  </time>
-{%- endunless -%}
+<time class="entry-date dt-published" datetime="{{ entry.date | date_to_xmlschema }}">
+  {%- assign date_format = site.date_format | default: "%B %-d, %Y" -%}
+  {{ entry.date | date: date_format }}
+</time>

--- a/_includes/entry.html
+++ b/_includes/entry.html
@@ -29,10 +29,12 @@
       {% endif %}
     </div>
   {% endunless %}
-  {% if site.read_time or entry.date and page.layout != 'collection' %}
-    <footer class="entry-meta">
-      {% if site.read_time %}{% include read-time.html %}{% endif %}
-      {% if entry.date %}{% include entry-date.html %}{% endif %}
-    </footer>
-  {% endif %}
+  {% unless page.show_dates == false %}
+    {% if site.read_time or entry.date and page.layout != 'collection' %}
+      <footer class="entry-meta">
+        {% if site.read_time %}{% include read-time.html %}{% endif %}
+        {% if entry.date %}{% include entry-date.html %}{% endif %}
+      </footer>
+    {% endif %}
+  {% endunless %}
 </article>

--- a/_layouts/collection.html
+++ b/_layouts/collection.html
@@ -1,5 +1,6 @@
 ---
 layout: page
+show_dates: false
 ---
 
 {{ content }}


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

using `show_dates: false` in the configuration, one is able to disable the appearance of a date per post.
