### PR TITLE
allow to disable 'previous' and 'next' links on posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ This layout accommodates the following front matter:
 | `author` | Object or string | Specify a post's author `name`, `picture`, `twitter`, `links`, etc. |
 | `comments` | Boolean | Disable comments with `comments: false`. |
 | `share` | Boolean | Add social share links to a post with `share: true`. |
+| `pagination` | Boolean | Disable *previous* and *next* links on a post with `pagination: false`. |
 
 **Post image example:**
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -34,7 +34,9 @@ layout: default
           {% include disqus-comments.html %}
         {% endif %}
 
-        {% include page-pagination.html %}
+        {% unless page.pagination == false %}
+          {% include page-pagination.html %}
+        {% endunless %}
       </div>
     </div>
   </article>


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

using `pagination: false` in the configuration, one is able to disable the appearance of the "previous" and "next" lnks on post pages, site-wide.