### PR TITLE
Modify the order of taxonomies

### DIFF
--- a/_includes/page-categories.html
+++ b/_includes/page-categories.html
@@ -1,7 +1,8 @@
 {% if page.categories.size > 0 %}
   <h3 class="page-taxonomies-title">{{ site.data.text[site.locale].categories | default: 'Categories' }}</h3>
+  {% assign categories = page.categories | sort %}
   <ul class="page-taxonomies">
-    {%- for category in page.categories -%}
+    {%- for category in categories -%}
       <li class="page-taxonomy">
         {%- if site.category_archive_path -%}
           <a class="p-category" href="{{ category | slugify | prepend: site.category_archive_path | relative_url }}" title="{{ site.data.text[site.locale].pages_categorized | default: 'Pages filed under' }} {{ category }}">{{ category }}</a>

--- a/_includes/page-tags.html
+++ b/_includes/page-tags.html
@@ -1,7 +1,8 @@
 {% if page.tags.size > 0 %}
   <h3 class="page-taxonomies-title">{{ site.data.text[site.locale].tags | default: 'Tags' }}</h3>
+  {% assign tags = page.tags | sort %}
   <ul class="page-taxonomies">
-    {%- for tag in page.tags -%}
+    {%- for tag in tags -%}
       <li class="page-taxonomy">
         {%- if site.tag_archive_path -%}
           <a href="{{ tag | slugify | prepend: site.tag_archive_path | relative_url }}" title="{{ site.data.text[site.locale].pages_tagged | default: 'Pages tagged' }} {{ tag }}" rel="tag">{{ tag }}</a>

--- a/_layouts/categories.html
+++ b/_layouts/categories.html
@@ -4,26 +4,6 @@ layout: page
 
 {{ content }}
 
-<ul class="taxonomy-index">
-  {% assign categories_max = 0 %}
-  {% for category in site.categories %}
-    {% if category[1].size > categories_max %}
-      {% assign categories_max = category[1].size %}
-    {% endif %}
-  {% endfor %}
-  {% for i in (1..categories_max) reversed %}
-    {% for category in site.categories %}
-      {% if category[1].size == i %}
-        <li>
-          <a href="#{{ category[0] | slugify }}">
-            <strong>{{ category[0] }}</strong> <span class="taxonomy-count">{{ i }}</span>
-          </a>
-        </li>
-      {% endif %}
-    {% endfor %}
-  {% endfor %}
-</ul>
-
 {% assign categories_max = 0 %}
 {% for category in site.categories %}
   {% if category[1].size > categories_max %}
@@ -31,18 +11,71 @@ layout: page
   {% endif %}
 {% endfor %}
 
+{% assign category_names_array = "" %}
+{% assign category_counts = "" %}
+{% assign first_array_element = true %}
 {% for i in (1..categories_max) reversed %}
+  {% assign category_names = "" %}
+  {% assign first_category = true %}
+
   {% for category in site.categories %}
     {% if category[1].size == i %}
-      <section id="{{ category[0] | slugify | downcase }}" class="taxonomy-section">
-        <h2 class="taxonomy-title">{{ category[0] }}</h2>
-        <div class="entries-{{ page.entries_layout | default: 'list' }}">
-          {% for entry in category.last %}
-            {% include entry.html %}
-          {% endfor %}
-        </div>
-        <a href="#page-title" class="back-to-top">{{ site.data.text[site.locale].back_to_top | default: 'Back to Top' }} &uarr;</a>
-      </section>
+      {% if first_category %}
+        {% assign first_category = false %}
+      {% else %}
+        {% assign category_names = category_names | append: "," %}
+      {% endif %}
+      {% assign category_names = category_names | append: category[0] %}
     {% endif %}
+  {% endfor %}
+
+  {% if category_names != "" %}
+    {% assign category_names = category_names | split: "," | sort | join: "," %}
+
+    {% if first_array_element %}
+      {% assign first_array_element = false %}
+    {% else %}
+      {% assign category_names_array = category_names_array | append: "|" %}
+      {% assign category_counts = category_counts | append: "|" %}
+    {% endif %}
+    {% assign category_names_array = category_names_array | append: category_names %}
+    {% assign category_counts = category_counts | append: i %}
+  {% endif %}
+{% endfor %}
+
+{% assign category_names_array = category_names_array | split: "|" %}
+{% assign category_counts = category_counts | split: "|" %}
+
+
+<ul class="taxonomy-index">
+  {% for category_names in category_names_array %}
+    {% assign category_names_list = category_names | split: "," %}
+    {% assign category_count = category_counts[forloop.index0] %}
+    {% for category_name in category_names_list %}
+      <li>
+        <a href="#{{ category_name | slugify }}">
+          <strong>{{ category_name }}</strong> <span class="taxonomy-count">{{ category_count }}</span>
+        </a>
+      </li>
+    {% endfor %}
+  {% endfor %}
+</ul>
+
+{% for category_names in category_names_array %}
+  {% assign category_names_list = category_names | split: "," %}
+  {% for category_name in category_names_list %}
+    <section id="{{ category_name | slugify | downcase }}" class="taxonomy-section">
+      <h2 class="taxonomy-title">{{ category_name }}</h2>
+      {% for category in site.categories %}
+        {% if category[0] == category_name %}
+          <div class="entries-{{ page.entries_layout | default: 'list' }}">
+            {% for entry in category.last %}
+              {% include entry.html %}
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% endfor %}
+      <a href="#page-title" class="back-to-top">{{ site.data.text[site.locale].back_to_top | default: 'Back to Top' }} &uarr;</a>
+    </section>
   {% endfor %}
 {% endfor %}

--- a/_layouts/tags.html
+++ b/_layouts/tags.html
@@ -4,26 +4,6 @@ layout: page
 
 {{ content }}
 
-<ul class="taxonomy-index">
-  {% assign tags_max = 0 %}
-  {% for tag in site.tags %}
-    {% if tag[1].size > tags_max %}
-      {% assign tags_max = tag[1].size %}
-    {% endif %}
-  {% endfor %}
-  {% for i in (1..tags_max) reversed %}
-    {% for tag in site.tags %}
-      {% if tag[1].size == i %}
-        <li>
-          <a href="#{{ tag[0] | slugify }}">
-            <strong>{{ tag[0] }}</strong> <span class="taxonomy-count">{{ i }}</span>
-          </a>
-        </li>
-      {% endif %}
-    {% endfor %}
-  {% endfor %}
-</ul>
-
 {% assign tags_max = 0 %}
 {% for tag in site.tags %}
   {% if tag[1].size > tags_max %}
@@ -31,18 +11,71 @@ layout: page
   {% endif %}
 {% endfor %}
 
+{% assign tag_names_array = "" %}
+{% assign tag_counts = "" %}
+{% assign first_array_element = true %}
 {% for i in (1..tags_max) reversed %}
+  {% assign tag_names = "" %}
+  {% assign first_tag = true %}
+
   {% for tag in site.tags %}
     {% if tag[1].size == i %}
-      <section id="{{ tag[0] | slugify | downcase }}" class="taxonomy-section">
-        <h2 class="taxonomy-title">{{ tag[0] }}</h2>
-        <div class="entries-{{ page.entries_layout | default: 'list' }}">
-          {% for entry in tag.last %}
-            {% include entry.html %}
-          {% endfor %}
-        </div>
-        <a href="#page-title" class="back-to-top">{{ site.data.text[site.locale].back_to_top | default: 'Back to Top' }} &uarr;</a>
-      </section>
+      {% if first_tag %}
+        {% assign first_tag = false %}
+      {% else %}
+        {% assign tag_names = tag_names | append: "," %}
+      {% endif %}
+      {% assign tag_names = tag_names | append: tag[0] %}
     {% endif %}
+  {% endfor %}
+
+  {% if tag_names != "" %}
+    {% assign tag_names = tag_names | split: "," | sort | join: "," %}
+
+    {% if first_array_element %}
+      {% assign first_array_element = false %}
+    {% else %}
+      {% assign tag_names_array = tag_names_array | append: "|" %}
+      {% assign tag_counts = tag_counts | append: "|" %}
+    {% endif %}
+    {% assign tag_names_array = tag_names_array | append: tag_names %}
+    {% assign tag_counts = tag_counts | append: i %}
+  {% endif %}
+{% endfor %}
+
+{% assign tag_names_array = tag_names_array | split: "|" %}
+{% assign tag_counts = tag_counts | split: "|" %}
+
+
+<ul class="taxonomy-index">
+  {% for tag_names in tag_names_array %}
+    {% assign tag_names_list = tag_names | split: "," %}
+    {% assign tag_count = tag_counts[forloop.index0] %}
+    {% for tag_name in tag_names_list %}
+      <li>
+        <a href="#{{ tag_name | slugify }}">
+          <strong>{{ tag_name }}</strong> <span class="taxonomy-count">{{ tag_count }}</span>
+        </a>
+      </li>
+    {% endfor %}
+  {% endfor %}
+</ul>
+
+{% for tag_names in tag_names_array %}
+  {% assign tag_names_list = tag_names | split: "," %}
+  {% for tag_name in tag_names_list %}
+    <section id="{{ tag_name | slugify | downcase }}" class="taxonomy-section">
+      <h2 class="taxonomy-title">{{ tag_name }}</h2>
+      {% for tag in site.tags %}
+        {% if tag[0] == tag_name %}
+          <div class="entries-{{ page.entries_layout | default: 'list' }}">
+            {% for entry in tag.last %}
+              {% include entry.html %}
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% endfor %}
+      <a href="#page-title" class="back-to-top">{{ site.data.text[site.locale].back_to_top | default: 'Back to Top' }} &uarr;</a>
+    </section>
   {% endfor %}
 {% endfor %}


### PR DESCRIPTION
This is an enhancement or feature. 

## Summary

Two modifications:

1. Categories and tags on each post are sorted by alphabetic.
2. Categories and tags on their archive pages are first sorted by the counts and then sorted by alphabetic.
