### PR TITLE
An elegant way to include images and videos on a post

### DIFF
--- a/_includes/image
+++ b/_includes/image
@@ -1,0 +1,14 @@
+{% capture post_images_root %}{{ site.post_images_root | default: "/assets/image/posts" }}{% endcapture %}
+{% if page.slug %}
+  {% capture image_path %}{{ page.slug }}/{{ include.name }}{% endcapture %}
+{% else %}
+  {% capture image_path %}{{ page.title | slugify }}/{{ include.name }}{% endcapture %}
+{% endif %}
+{% if include.caption %}
+  <figure class="{{ include.align | default: "align-center" }}">
+    <img src="{{ post_images_root }}/{{ image_path }}" {% if include.alt %} alt="{{ include.alt }}" {% endif %} {% if include.width %} width="{{ include.width }}" {% endif %}/>
+    <figcaption>{{ include.caption }}</figcaption>
+  </figure>
+{% else %}
+  <img class="{{ include.align | default: "align-center" }}" src="{{ post_images_root }}/{{ image_path }}" {% if include.alt %} alt="{{ include.alt }}" {% endif %} {% if include.width %} width="{{ include.width }}" {% endif %}/>
+{% endif %}

--- a/_includes/video
+++ b/_includes/video
@@ -1,0 +1,9 @@
+{% capture post_videos_root %}{{ site.post_videos_root | default: "/assets/video/posts" }}{% endcapture %}
+{% if page.slug %}
+  {% capture video_path %}{{ page.slug }}/{{ include.name }}{% endcapture %}
+{% else %}
+  {% capture video_path %}{{ page.title | slugify }}/{{ include.name }}{% endcapture %}
+{% endif %}
+<video class="{{ include.align | default: "align-center" }}" {% if include.width %} width="{{ include.width }}" {% endif %} {% if include.autoplay %}autoplay{% endif %} controls>
+  <source src="{{ post_videos_root }}/{{ video_path }}">
+</video>


### PR DESCRIPTION
This is an enhancement or feature. 

## Summary

Here I provide two templates `image` and `video` to let users elegantly include images and videos on a post.

The first problem we need to resolve is how to organize post-specific assets. If we put all the images into the folder `assets/image`, we can't quickly distinct which images belong to which posts. So I provide a default strategy. For example, all images included by `an-example-post.md` would be placed in the path `assets/image/posts/an-example-post`. But, of course, the root path is customizable in `config.yml`:

```
post_images_root: "/assets/image/posts"
```

In the Markdown syntax, the normal way to include an image is like this:

```
![]({{ "/assets/image/posts/an-example-post/an-example-image.png" | absolute_url }})
```

If the number of images is very large, we have to write a lot of redundant code. This pain can be resolved by the `image` template:

```
{% include image name="an-example-image.png" %}
```

Besides, you can specify its width, alignment and caption:

```
{% include image name="an-example-image.png" caption="An image" width="60%" align="align-left" %}
```

The mechanism of the `video` template is similar:

```
{% include video name="an-example-video.mp4" %}
{% include video name="another-example-video.mp4" width="80%" autoplay=true %}
```



