### PR TITLE
Support passing entries to document collection

### DIFF
--- a/_includes/documents-collection.html
+++ b/_includes/documents-collection.html
@@ -1,4 +1,8 @@
-{% assign entries = site[include.collection] %}
+{% if include.entries %}
+  {% assign entries = include.entries %}
+{% else %}
+  {% assign entries = site[include.collection] %}
+{% endif %}
 
 {% if include.sort_by == 'title' %}
   {% if include.sort_order == 'reverse' %}


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Support of passing an arbitrary entries to `documents-collection` include via attribute `entries`.

## Context

The `documents-collection` works well when using named collections. When you want something more fancy and display multiple collections on a page, think of a portfolio divided in Professional/Personal stuff this is currently not possible as the data is retrieved 

```
{% assign entries = site.works | where_exp: "item", "item.categories contains 'Professional'" %}
{% include works-collection.html title="Professional" entries=entries %}
```
