### PR TITLE
Fixing MathJax rendering

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -34,22 +34,6 @@
 MathJax = {
   tex: {
       tags: "{{ site.mathjax.tags | default: 'ams' }}"    // eq numbering options: none, ams, all
-  },
-  options: {
-    renderActions: {
-      // for mathjax 3, handle <script "math/tex"> blocks inserted by kramdown
-      find: [10, function (doc) {
-        for (const node of document.querySelectorAll('script[type^="math/tex"]')) {
-          const display = !!node.type.match(/; *mode=display/);
-          const math = new doc.options.MathItem(node.textContent, doc.inputJax[0], display);
-          const text = document.createTextNode('');
-          node.parentNode.replaceChild(text, node);
-          math.start = {node: text, delim: '', n: 0};
-          math.end = {node: text, delim: '', n: 0};
-          doc.math.push(math);
-        }
-      }, '']
-    }
   }
 }
 </script>


### PR DESCRIPTION
This is a bug fix.

## Summary

MathJax isn't rendering properly on the [sample page](https://mmistakes.github.io/so-simple-theme/mathjax-example/) or on my blog. I think this may be related to a Kramdown update on Github pages that's causing the problem.

It looks like there's a workaround in `scripts.html` that's no longer required, so I've just removed this.

I've tested this locally on the example pages and it fixes the rendering problem.

## Context

I think this is also related to #388.
