### PR TITLE
Add body-custom include to facilitate loading custom elements at the body start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1065,11 +1065,12 @@ Theme files can be [overridden](http://jekyllrb.com/docs/themes/#overriding-them
 
 **ProTip:** to locate the theme's files on your computer run `bundle show jekyll-theme-so-simple`. This returns the location of the gem-based theme files.
 
-The theme comes with two files to help inject custom markup and content into predefined locations.
+The theme comes with three files to help inject custom markup and content into predefined locations.
 
 |     | Description |
 | --- | ----------- |
 | [`_includes/head-custom.html`](_includes/head-custom.html) | Inserted inside the `<head>` element for adding metadata, favicons, etc. |
+| [`_includes/body-custom.html`](_includes/body-custom.html) | Inserted inside the `<body>` element for adding Google Tag Manager, etc. |
 | [`_includes/footer-custom.html`](_includes/footer-custom.html) | Inserted inside the `<footer>` element before site scripts and copyright information. |
 
 ### Customizing Sass (SCSS)

--- a/_includes/body-custom.html
+++ b/_includes/body-custom.html
@@ -1,0 +1,3 @@
+<!-- start custom body snippets -->
+
+<!-- end custom body snippets -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,7 @@
   {% include head.html %}
 
   <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %} {% if page.entries_layout == 'grid' %}page--wide{% endif %} {{ page.title | slugify }}">
+    {% include body-custom.html %}
     {% include skip-links.html %}
     {% include navigation.html %}
     {% include masthead.html %}


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/so-simple-theme#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix.
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

Hi, I am in the process of setting up Google Tag Manager and am using the [t-richards/jekyll-google-tag-manager](https://github.com/t-richards/jekyll-google-tag-manager) plugin. GTM seems to require code to be inserted as the first thing in the `<body>` element in order to function. To support this I have introduced a `body-custom.html` include. I thought this have other, more general, use cases so wanted to offer it back in case you are keen to include it. Having it included upstream also benefits me of course as I no longer have to maintain a custom `default.html` :grin: .

Let me know what you think, but regardless of your decision thank you for all your work on the theme, it's really excellent :pray: 

Edd 