### PR TITLE
masthead: Prefer tagline over description and add defaults for title.

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -8,11 +8,11 @@
     {% assign page_image = page.image.path | default: page.image %}
     {% unless page_image %}
       {% if page.url == '/' %}
-        <h1 class="site-title animated fadeIn"><a href="{{ '/' | relative_url }}">{{ site.title }}</a></h1>
+        <h1 class="site-title animated fadeIn"><a href="{{ '/' | relative_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
       {% else %}
-        <div class="site-title animated fadeIn"><a href="{{ '/' | relative_url }}">{{ site.title }}</a></div>
+        <div class="site-title animated fadeIn"><a href="{{ '/' | relative_url }}">{{ site.title | default: site.github.repository_name }}</a></div>
       {% endif %}
-      <p class="site-description animated fadeIn" itemprop="description">{{ site.description }}</p>
+      <p class="site-description animated fadeIn" itemprop="description">{{ site.tagline | default: site.description | default: site.github.project_tagline }}</p>
     {% endunless %}
   </div>
 </header><!-- /.masthead -->


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/so-simple-theme#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is an enhancement or feature. 

## Summary
SEO usually prefers a slightly longer description, so `jekyll-seo-tag` allows to separate a short tagline from a longer description. 
This PR prefers `site.tagline` over `site.description` if it is set, and also adds another fallback to `site.github.project_tagline`.
It also adds a fallback to `site.github.repository_name` in case `site.title` is not set. 

