### PR TITLE
Google Analytics 4 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,10 +459,10 @@ If you don't want to display comments for a particular post you can disable them
 
 ### Google Analytics
 
-To enable [**Google Analytics**](https://analytics.google.com/analytics/web/), add your tracking ID to `_config.yml` like so:
+To enable [**Google Analytics**](https://analytics.google.com/analytics/web/), add your Measurement ID to `_config.yml` like so:
 
 ```yaml
-google_analytics: UA-NNNNNNNN-N
+google_analytics: G-NNNNNNNNNN
 ```
 
 Similar to Disqus comments above, the Google Analytics tracking script will only appear in production when using the following environment value: `JEKYLL_ENV=production`.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,15 @@
 <head>
+  {%- if jekyll.environment == 'production' and site.google_analytics -%}
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '{{ site.google_analytics }}');
+    </script>
+  {%- endif %}
+
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -13,6 +13,7 @@
   <script src="https://use.fontawesome.com/releases/v5.0.12/js/all.js"></script>
 {%- endif -%}
 
+<!-- "Old" Tracking ID with Google Analytics 3
 {%- if jekyll.environment == 'production' and site.google_analytics -%}
   <script>
   if(!(window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1")) {
@@ -25,7 +26,7 @@
   }
   </script>
 {%- endif %}
-
+-->
 {% if site.mathjax == true or site.mathjax.enable == true %}
 <!-- MathJax -->
 {% capture mathjaxjs %}https://cdn.jsdelivr.net/npm/mathjax@3/es5/{{ site.mathjax.combo | default: "tex-svg" }}.js{% endcapture %}


### PR DESCRIPTION
- Tracking ID Changed to Measurements ID

- Added Google Tag to head.html since scripts.html does not get populated in any output/built files

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/so-simple-theme#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

<!--
  Google Analytics has changed to GA4. Tracking ID is now Measurement ID which uses gtag( ) instead of ga( )
-->

## Context

<!--
  Is this related to any GitHub issue(s)?
-->
